### PR TITLE
keep file name and extension of source (fix Typescript transpilation)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ var gutil = require('gulp-util'),
 // Converts the relative path in file.sourceMap.sources[0] to be relative
 // not to the source files base directory, but to the output directory of
 // the particular file.
-// For example, transpiling "src/folder/file.js" to "dist/folder/file.js"
-// needs the file.sourceMap.sources[0] value "../../src/folder/file.js".
+// For example, transpiling "src/folder/file.ts" to "dist/folder/file.js"
+// needs the file.sourceMap.sources[0] value "../../src/folder/file.ts".
 module.exports = function (options) {
   // {dest: 'dist'} => options
   if (!(options && options.dest)) {
@@ -24,9 +24,12 @@ module.exports = function (options) {
       var sourceDir = path.dirname(file.relative),
       // path.join('/project', 'dist', 'folder') => '/project/dist/folder'
           outputDir = path.join(file.cwd, options.dest, sourceDir);
-      // path.relative('/project/dist/folder', '/project/src/folder/file.js')
-      //   => '../../src/folder/file.js'
-      file.sourceMap.sources[0] = path.relative(outputDir, file.path);
+      // path.join('/project/src/folder/', 'file.ts');
+      var sourceFile = path.join(path.dirname(file.path),
+                                 path.basename(file.sourceMap.sources[0]));
+      // path.relative('/project/dist/folder', '/project/src/folder/file.ts')
+      //   => '../../src/folder/file.ts'
+      file.sourceMap.sources[0] = path.relative(outputDir, sourceFile);
     }
     done(null, file);
   });

--- a/test.js
+++ b/test.js
@@ -32,9 +32,9 @@ describe('relativeSourcemapsSource()', function () {
         ];
     // Simulate how gulp-sourcemaps sets paths to source files -
     // relatively to the source base directory
-    files[0].sourceMap = {sources: ['file.js']};
-    files[1].sourceMap = {sources: ['file.js']};
-    files[2].sourceMap = {sources: ['folder/file.js']};
+    files[0].sourceMap = {sources: ['file.ts']};
+    files[1].sourceMap = {sources: ['file.ts']};
+    files[2].sourceMap = {sources: ['folder/file.ts']};
 
     stream.on('data', function (file) {
       buffer.push(file);
@@ -44,9 +44,9 @@ describe('relativeSourcemapsSource()', function () {
       assert.equal(buffer.length, 3);
       // Updated paths point from the output file location in the "dist"
       // directory tree to the source file below the source base directory
-      assert.equal(buffer[0].sourceMap.sources[0], '../file.js');
-      assert.equal(buffer[1].sourceMap.sources[0], '../src/file.js');
-      assert.equal(buffer[2].sourceMap.sources[0], '../../src/folder/file.js');
+      assert.equal(buffer[0].sourceMap.sources[0], '../file.ts');
+      assert.equal(buffer[1].sourceMap.sources[0], '../src/file.ts');
+      assert.equal(buffer[2].sourceMap.sources[0], '../../src/folder/file.ts');
       done();
     });
 


### PR DESCRIPTION
When using gulp-typescript to transpile, the gulp-relative-sourcemaps-source is loosing file name and extension. The `file.ts` becomes `file.js` during the computation of the relative path. This pull request fixes the problem.
