### PR TITLE
Add check to make sure sourceMap sources is not empty. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function (options) {
   }
   return through.obj(function (file, encoding, done) {
     // Detect a file with a sourcemaps and an external content
-    if (file.sourceMap && Array.isArray(file.sourceMap.sources)) {
+    if (file.sourceMap && Array.isArray(file.sourceMap.sources) && file.sourceMap.sources.length > 0) {
       // path.dirname('folder/file.js') => 'folder'
       var sourceDir = path.dirname(file.relative),
       // path.join('/project', 'dist', 'folder') => '/project/dist/folder'


### PR DESCRIPTION
Node 6 throws an exception when undefined is passed to path.basename.

gulp-typescript will sometimes pass an empty sources list in cases when the input file compiles to no javascript (i.e. a file just of interface definitions). I don't know gulp and gulp-sourcemap well enough to know if it's expected to have an empty sources list or not. But seems like a good check to include regardless.
